### PR TITLE
NEW: Added systemd services to autostart on boot

### DIFF
--- a/scripts/fan.service
+++ b/scripts/fan.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fan Service
+After=network.target syslog.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/iot/scripts
+ExecStart=/bin/bash /home/pi/iot/scripts/start_fan.sh
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/heartrate.service
+++ b/scripts/heartrate.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fan Service
+After=network.target syslog.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/iot/scripts
+ExecStart=/bin/bash /home/pi/iot/scripts/start_heartrate.sh
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/kickr.service
+++ b/scripts/kickr.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fan Service
+After=network.target syslog.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/iot/scripts
+ExecStart=/bin/bash /home/pi/iot/scripts/start_kickr.sh
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/workout.service
+++ b/scripts/workout.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fan Service
+After=network.target syslog.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/iot/scripts
+ExecStart=/bin/bash /home/pi/iot/scripts/start_workout.sh
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The service files under scripts can be copied to /lib/systemd/system and enabled with systemctl enable xxxx.service to allow the appropriate services to start at boot. There is currently no cadence script because we use the cadence returned from the kickr driver rather than the cadence sensor on the pedal but it could be written in a similar way